### PR TITLE
fixed symlink file check

### DIFF
--- a/lib/File/Stamped.pm
+++ b/lib/File/Stamped.pm
@@ -73,7 +73,7 @@ sub _gen_symlink {
     my ($self, $fname) = @_;
 
     if (defined(my $symlink = *$self->{symlink})) {
-        if (-e $symlink) {
+        if (-l $symlink) {
             my $link = readlink $symlink;
             if (defined $link && $link ne $fname) {
                 unlink $symlink;


### PR DESCRIPTION
-eだとリンクの参照先の実体ファイルの存在をチェックしてしまうので、-lでsymlinkかどうかのチェックを行なうのが正しい
