### PR TITLE
Adapt syswrite for perl-5.30 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ You can use "myapp.log.%Y%m%d.log" style log file.
 
         This is IO mode for opening file.
 
-        Default value is '>>:utf8'.
+        Default value is '>>:utf8'.  However, for perl-5.30 compatibility,
+        '>>:raw' is used for syswrite.
 
     - autoflush: Bool
 

--- a/README.mkdn
+++ b/README.mkdn
@@ -40,7 +40,8 @@ File::Stamped is utility for time stamped log file.
 
         This is IO mode for opening file.
 
-        Default value is '>>:utf8'.
+        Default value is '>>:utf8'.  However, for perl-5.30 compatibility,
+        '>>:raw' is used for syswrite.
 
     - autoflush: Bool
 

--- a/lib/File/Stamped.pm
+++ b/lib/File/Stamped.pm
@@ -138,6 +138,8 @@ sub syswrite {
 
     my ($buf, @args) = @_;
 
+    local *$self->{iomode} = '>>:raw'; # perl-5.30 syswrite compatibility
+
     $self->_output(sub {
         my ($fh, $fname) = @_;
         unless ($fh) {
@@ -224,7 +226,8 @@ Default value is 1.
 
 This is IO mode for opening file.
 
-Default value is '>>:utf8'.
+Default value is '>>:utf8'.  However, for perl-5.30 compatibility, '>>:raw' is
+used for C<syswrite>.
 
 =item autoflush: Bool
 

--- a/t/06_syswrite.t
+++ b/t/06_syswrite.t
@@ -29,10 +29,10 @@ my $fname = do {
     closedir $dh;
     $fname;
 };
-like basename($fname), qr{^foo.\d{8,}\.log$};
+like basename($fname), qr{^foo.\d{8,}\.log$}, "Got expected file basename";
 open my $fh, '<', $fname or die;
 my $content = do { local $/; <$fh> };
-is $content, "OK\nOK2\nOK3\nOK4\n";
+is $content, "OK\nOK2\nOK3\nOK4\n", "Got expected file content";
 
 done_testing;
 


### PR DESCRIPTION
As of Perl 5.30, the core syswrite() function no longer accepts utf8
filehandles.  For this module's syswrite function, instead use '>>:raw' as IO
mode.

References:

https://rt.cpan.org/Ticket/Display.html?id=127361
https://rt.perl.org/Ticket/Display.html?id=133585